### PR TITLE
Fixing Issue Docker not found #9

### DIFF
--- a/ansible/roles/prepare_env/tasks/DockerInstallation.yml
+++ b/ansible/roles/prepare_env/tasks/DockerInstallation.yml
@@ -1,0 +1,93 @@
+---
+- name: Install required packages (Debian/Ubuntu)
+  apt:
+    name: "{{ item }}"
+    state: present
+    update_cache: yes
+  loop:
+    - apt-transport-https
+    - ca-certificates
+    - curl
+    - software-properties-common
+  when: ansible_os_family == "Debian"
+
+- name: Install required packages (RedHat/CentOS)
+  yum:
+    name: "{{ item }}"
+    state: present
+  loop:
+    - yum-utils
+    - device-mapper-persistent-data
+    - lvm2
+  when: ansible_os_family == "RedHat"
+
+- name: Add Docker GPG key (Debian/Ubuntu)
+  apt_key:
+    url: https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg
+    state: present
+  when: ansible_os_family == "Debian"
+
+- name: Add Docker repository (Debian/Ubuntu)
+  apt_repository:
+    repo: "deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
+    state: present
+  when: ansible_os_family == "Debian"
+
+- name: Install Docker (Debian/Ubuntu)
+  apt:
+    name: docker-ce
+    state: present
+    update_cache: yes
+  when: ansible_os_family == "Debian"
+
+- name: Add Docker repository (RedHat/CentOS)
+  yum_repository:
+    name: docker
+    description: Docker Repository
+    baseurl: https://download.docker.com/linux/centos/7/x86_64/stable
+    gpgcheck: yes
+    gpgkey: https://download.docker.com/linux/centos/gpg
+    state: present
+  when: ansible_os_family == "RedHat"
+
+- name: Install Docker (RedHat/CentOS)
+  yum:
+    name: docker-ce
+    state: present
+  when: ansible_os_family == "RedHat"
+
+- name: Start and enable Docker service
+  service:
+    name: docker
+    state: started
+    enabled: "{{ lookup('env', 'START_ON_BOOT') | default('yes') == 'yes' }}"
+
+- name: Add user to Docker group
+  user:
+    name: "{{ lookup('env', 'DOCKER_USER') | default('ansible_user') }}"
+    groups: docker
+    append: yes
+  when: docker_user != ''
+
+- name: Install Docker Compose v2
+  shell: |
+    curl -L "https://github.com/docker/compose/releases/download/{{ lookup('env', 'DOCKER_COMPOSE_VERSION') | default('2.19.0') }}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+    chmod +x /usr/local/bin/docker-compose
+  args:
+    creates: /usr/local/bin/docker-compose
+
+- name: Verify Docker installation
+  command: docker --version
+  register: docker_version_output
+
+- name: Verify Docker Compose installation
+  command: docker-compose --version
+  register: docker_compose_version_output
+
+- name: Print Docker version
+  debug:
+    msg: "Docker version installed: {{ docker_version_output.stdout }}"
+
+- name: Print Docker Compose version
+  debug:
+    msg: "Docker Compose version installed: {{ docker_compose_version_output.stdout }}"

--- a/ansible/roles/prepare_env/tasks/main.yml
+++ b/ansible/roles/prepare_env/tasks/main.yml
@@ -4,3 +4,6 @@
 
 - name: copy and sync files and directories
   ansible.builtin.include_tasks: "{{ role_path }}/tasks/files_and_directories.yml"
+
+- name: Check Docker installation on server
+  ansible.builtin.include_tasks: "{{ role_path }}/tasks/DockerInstallation.yml

--- a/artifacts/wiki/index.html
+++ b/artifacts/wiki/index.html
@@ -128,6 +128,58 @@
                 <h2 id="configurations" class="section-header">Configurations</h2>
                 <h3 class="env-var section-header" id="environment-variables">Environment Variables</h3>
                 <p>Environment variables need to be configured for both Vault and Boundary. Here's an example:</p>
+                
+                <p>The following environment variables can be used to customize the behavior of the DockerInstallation playbook:</p>
+
+                <ul>
+                    <li>
+                        <strong>START_ON_BOOT</strong>
+                        <ul>
+                            <li><strong>Type:</strong> Optional</li>
+                            <li><strong>Default:</strong> yes</li>
+                            <li><strong>Description:</strong> Controls whether the Docker service is enabled to start on boot. 
+                                If set to <code>yes</code>, Docker will start automatically on boot. If not provided, 
+                                it defaults to <code>yes</code>, meaning Docker will be enabled to start on boot by default. 
+                                To prevent this, set the value to <code>no</code>.
+                            </li>
+                        </ul>
+                    </li>
+                    <li>
+                        <strong>DOCKER_USER</strong>
+                        <ul>
+                            <li><strong>Type:</strong> Optional</li>
+                            <li><strong>Default:</strong> ansible_user</li>
+                            <li><strong>Description:</strong> Specifies which user should be added to the Docker group, 
+                                granting that user permission to run Docker commands without requiring <code>sudo</code>. 
+                                If this variable is not set, the user running the Ansible playbook (referred to as 
+                                <code>ansible_user</code>) will be added to the Docker group. If a specific user is 
+                                provided in this environment variable, that user will be added instead.
+                            </li>
+                        </ul>
+                    </li>
+                    <li>
+                        <strong>DOCKER_COMPOSE_VERSION</strong>
+                        <ul>
+                            <li><strong>Type:</strong> Optional</li>
+                            <li><strong>Default:</strong> 2.0.0</li>
+                            <li><strong>Description:</strong> Specifies the version of Docker Compose to install. If 
+                                omitted, it defaults to version 2.0.0.
+                            </li>
+                        </ul>
+                    </li>
+                </ul>
+            </div>
+
+            <div class="return-codes section">
+                <h2 id="returnexit-codes" class="section-header">Return/Exit Codes</h2>
+                <p>The return/exit codes of the various tasks within DockerInstallation playbook are as follows:</p>
+                <ul>
+                    <li><code>0</code>: Success - The task completed successfully without any errors.</li>
+                    <li><code>1</code>: Failure - The task failed to complete successfully, indicating an error occurred.</li>
+                    <li><code>2</code>: Skipped - The task was skipped, usually due to a condition that was not met.</li>
+                </ul>
+            </div>
+                
                 <h4>STACK_ENV (mandatory)</h4>
                 <p>This variable determines in which mode/environment the stack is deployed.</p>
                 <ul class="options">


### PR DESCRIPTION
The playbook ```DockerInstallation``` is responsible for installing Docker and Docker ComposeV2 on systems running Debian/Ubuntu or RedHat/CentOS using Ansible. The explanation of how the environment variables interact with this playbook, particularly in relation to the Environment Variables section in ```artifacts/wiki/index.html```